### PR TITLE
Don't overwrite archive file if it already exists

### DIFF
--- a/src/data_file.rs
+++ b/src/data_file.rs
@@ -99,6 +99,11 @@ pub fn archive(file: &Path) {
     let file_name = format!("{}.txt", date);
     let full_path = archive_directory.join(file_name);
 
+    if full_path.exists() {
+        println!("Archive already exists for today. Delete it before archiving again.");
+        return;
+    }
+
     let standup: Standup = read_from_file(file);
 
     fs::write(full_path, standup.to_string()).expect("Failed to write archive file.");


### PR DESCRIPTION
`laydown archive` currently overwrites existing archive files without a
warning. This made me lose todays archive by my own stupidity. This
commit will prevent that this will happen to others.

---

Me again. This will prevent running `laydown archive` twice from overwriting the archive of the day.